### PR TITLE
dont count normal raw acceptor exits against restart policy

### DIFF
--- a/src/acceptor_pool.erl
+++ b/src/acceptor_pool.erl
@@ -332,7 +332,6 @@ terminate(_, State) ->
     terminate_report(Name, Id, AMod, Restart, Shutdown, Type, Reports).
 
 %% internal
-%start => {grpcbox_acceptor, {Transport, ServerOpts, ChatterboxOpts, SslOpts}, []}
 init(Name, Mod, Args, {ok, {#{} = Flags, [#{} = Spec]}}) ->
     case validate_config(Flags, Spec) of
         ok ->
@@ -445,7 +444,7 @@ start_loop(_, 0, Acceptors, _) ->
     Acceptors;
 start_loop(SockRef, N, Acceptors, State) ->
     start_loop(SockRef, N-1, start_acceptor(SockRef, Acceptors, State), State).
-%start => {grpcbox_acceptor, {Transport, ServerOpts, ChatterboxOpts, SslOpts}, []}
+
 start_acceptor(SockRef, Acceptors,
                #state{sockets=Sockets, start={Mod, Args, Opts}}) ->
     case Sockets of
@@ -527,7 +526,7 @@ restart_acceptor(normal = _ExitReason, SockRef, Acceptors, State) ->
 restart_acceptor(shutdown = _ExitReason, SockRef, Acceptors, State) ->
     NAcceptors = start_acceptor(SockRef, Acceptors, State),
     {noreply, State#state{acceptors=NAcceptors}};
-restart_acceptor({shutdown = _} = _ExitReason, SockRef, Acceptors, State) ->
+restart_acceptor({shutdown, _} = _ExitReason, SockRef, Acceptors, State) ->
     NAcceptors = start_acceptor(SockRef, Acceptors, State),
     {noreply, State#state{acceptors=NAcceptors}};
 restart_acceptor(_ExitReason, SockRef, Acceptors, State) ->


### PR DESCRIPTION
**note1:  for context the acceptor pool implements its own custom supervisor behaviour.**

**note2:  this fix is complimentary to the previous fix in which the restart strategy was upped from 1:5 to 50:2.  It does not replace it but it may allow the restart strategy to move away from being so lenient to something more restrictive**

**note3:  if we dont merge this its fine...as mentioned above it wont really make things better than the previous patch but could be considered a more correct fix...but as the sup behaviour is already custom this could be argued both ways**

This fixes a bug in the acceptor pool which would see the existing pool being dropped when a single raw acceptor from the pool terminates.  

The acceptor pool workers default to temporary child types and are basically a bunch of h2_connections which can be in one of two states:

- raw
- established

A raw acceptor is one which is not assigned to a client, its is sitting in the pool awaiting to be assigned to a connecting client at which point it becomes an established connection.

When a raw acceptor terminates, be that with a normal or abnormal exit reason, it is always counted against the restart policy ( which was defaulting to 1 restart in 5 secs )...so a single raw acceptor going down takes down the entire pool as it results in a breach of the sup restart policy.

An established acceptor going down does not result in the same behaviour.  Instead the implementation does not count exits from these acceptors against the restart policy and thus never end up in a breach of that sup restart policy.  

This behaviour difference between an established acceptor and a raw acceptor explains why the logs show a lot of acceptors exits not resulting in the pool being dropped.

The log extract below shows an established acceptor terminating:

```
[2022-07-19 03:34:37.568] <0.4410.1151> [error] [] Supervisor 'grpcbox_pool_0.0.0.0_8080' had child {grpcbox_acceptor,{{88,245,137,12},62164},
                  {{172,31,33,253},8080},
                  #Ref<0.498981140.3425435735.244642>} started with {grpcbox_acceptor,acceptor_init,undefined} at <0.1975.7596> exit with reason etimedout in context child_terminated
```

This did not result in the pool being dropped

The log extract below shows a raw acceptor terminating:

```
[2022-07-19 05:09:48.987] <0.31996.2308> [error] [] Supervisor 'grpcbox_pool_0.0.0.0_8080' had child {grpcbox_acceptor,undefined,
                  {{0,0,0,0},8080},
                  #Ref<0.498981140.3461087262.199255>} started with {grpcbox_acceptor,acceptor_init,undefined} at <0.10229.3617> exit with reason {shutdown,normal} in context start_error
[2022-07-19 05:09:48.987] <0.31996.2308> [error] [] Supervisor 'grpcbox_pool_0.0.0.0_8080' had child {grpcbox_acceptor,undefined,undefined,undefined} started with {grpcbox_acceptor,acceptor_init,undefined} at undefined exit with reason reached_max_restart_intennsity in context shutdown
```

And as evident the pool is restarted due to a restart breach

Whilst the pool workers are defined ( by default ) as temporary child types, in practise the workers end up having differing restart requirements depending on whether they are a raw acceptor or an established connection.  

A raw acceptor will always be restarted upon exit and so it behaves like a permanent child.  

However an established acceptor will never be restarted irrespective of the exit reason and so behaves like a temporary child.  This makes sense, as in this scenario it is better to allow the client to reconnect and start a new connection.   

The acceptor process itself however is the same process irrespective of whether it is a raw acceptor or an established acceptor....so the worker moves between two varying restart type implementations

The fix I have added here is to harmonize the restart policy implementation for an acceptor whether it is in a raw or established state.  This provides more 'grace' for raw acceptors to fail...the same grace which is already applied to established acceptors.  In essence the restart strategy acts like that of a transient child for all acceptors now whilst maintaining the temporary child restart behaviour for established acceptors and permanent child restart behaviour for raw acceptors.
